### PR TITLE
support multiple sample docs

### DIFF
--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -10,21 +10,17 @@ for config in $CONFIGS; do
     associated_jsons=$(echo "$LINES" | grep -v "config.json" | grep ".json" | grep "/${config_path[1]}/")
 
     for json in $associated_jsons; do
-        jsonPath=(${json//\.\// })
-        jsonPathString=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
-        fileNameJson=(${json//\.json/ })
-        fileName=(${fileNameJson//\// })
-        pdfFiles=$(echo "$LINES" | grep -v ".json" | grep "${fileName[1]}_sample") 
-        for pdfFile in $pdfFiles; do
-            if grep -q "$pdfFile" <<< "$LINES";
+        filePath=(${json//\.json/ })
+        pdfPaths=$(echo "$LINES" | grep -v ".json" | grep "${filePath}_sample") 
+        for pdfPath in $pdfPaths; do
+            jsonFile=(${json//\.\// })
+            jsonFileString=("{\"path\":\"${jsonFile}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonFile}\"}")
+            if [[ ! ${files[@]} =~ $jsonFileString ]];
             then
-                if ! grep -q "$jsonPathString" <<< "${files[@]}"; 
-                then
-                    files+=($jsonPathString)
-                fi
-                pdfPath=(${pdfFile//\.\// })
-                files+=("{\"path\":\"${pdfPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfPath}\"}")
+                files+=("$jsonFileString")
             fi
+            pdfFile=(${pdfPath//\.\// })
+            files+=("{\"path\":\"${pdfFile}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfFile}\"}")
         done
     done
 

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -11,14 +11,16 @@ for config in $CONFIGS; do
 
     for json in $associated_jsons; do
         jsonPath=(${json//\.\// })
-        files+=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
-
         fileNameJson=(${json//\.json/ })
         fileName=(${fileNameJson//\// })
         pdfFiles=$(echo "$LINES" | grep -v ".json" | grep "${fileName[1]}_sample") 
         for pdfFile in $pdfFiles; do
             if grep -q "$pdfFile" <<< "$LINES";
             then
+                if ! grep -q "$jsonPathString" <<< "${files[@]}"; 
+                then
+                    files+=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
+                fi
                 pdfPath=(${pdfFile//\.\// })
                 files+=("{\"path\":\"${pdfPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfPath}\"}")
             fi

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -39,4 +39,3 @@ for config in $CONFIGS; do
     }')
 done | jq -s )
 echo $MANIFEST >> output/manifest.json
-

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -11,6 +11,7 @@ for config in $CONFIGS; do
 
     for json in $associated_jsons; do
         jsonPath=(${json//\.\// })
+        jsonPathString=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
         fileNameJson=(${json//\.json/ })
         fileName=(${fileNameJson//\// })
         pdfFiles=$(echo "$LINES" | grep -v ".json" | grep "${fileName[1]}_sample") 
@@ -19,7 +20,7 @@ for config in $CONFIGS; do
             then
                 if ! grep -q "$jsonPathString" <<< "${files[@]}"; 
                 then
-                    files+=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
+                    files+=($jsonPathString)
                 fi
                 pdfPath=(${pdfFile//\.\// })
                 files+=("{\"path\":\"${pdfPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfPath}\"}")

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -39,3 +39,4 @@ for config in $CONFIGS; do
     }')
 done | jq -s )
 echo $MANIFEST >> output/manifest.json
+

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir output
 DOWNLOAD_URL_PREFIX="https://raw.githubusercontent.com/sensible-hq/sensible-sample-documents/main/"
-LINES=$(find . -name "*.*" | grep -v "\/\." | grep ".json\|.pdf\|.png")
+LINES=$(find . -name "*.*" | grep -v "\/\." | grep ".json\|.pdf")
 CONFIGS=$(echo "$LINES" | grep "config.json")
 MANIFEST=$(
 for config in $CONFIGS; do

--- a/.github/generate-manifest.sh
+++ b/.github/generate-manifest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 mkdir output
 DOWNLOAD_URL_PREFIX="https://raw.githubusercontent.com/sensible-hq/sensible-sample-documents/main/"
-LINES=$(find . -name "*.*" | grep -v "\/\." | grep ".json\|.pdf")
+LINES=$(find . -name "*.*" | grep -v "\/\." | grep ".json\|.pdf\|.png")
 CONFIGS=$(echo "$LINES" | grep "config.json")
 MANIFEST=$(
 for config in $CONFIGS; do
@@ -10,17 +10,19 @@ for config in $CONFIGS; do
     associated_jsons=$(echo "$LINES" | grep -v "config.json" | grep ".json" | grep "/${config_path[1]}/")
 
     for json in $associated_jsons; do
-        fileName=(${json//\.json/ })
-        pdfFile="${fileName}_sample.pdf"
-        if grep -q "$pdfFile" <<< "$LINES";
-        then
-            jsonPath=(${json//\.\// })
-            pdfPath=(${pdfFile//\.\// })
-            files+=(
-                "{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}"
-                "{\"path\":\"${pdfPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfPath}\"}"
-            )
-        fi
+        jsonPath=(${json//\.\// })
+        files+=("{\"path\":\"${jsonPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${jsonPath}\"}")
+
+        fileNameJson=(${json//\.json/ })
+        fileName=(${fileNameJson//\// })
+        pdfFiles=$(echo "$LINES" | grep -v ".json" | grep "${fileName[1]}_sample") 
+        for pdfFile in $pdfFiles; do
+            if grep -q "$pdfFile" <<< "$LINES";
+            then
+                pdfPath=(${pdfFile//\.\// })
+                files+=("{\"path\":\"${pdfPath}\",\"download_url\":\"${DOWNLOAD_URL_PREFIX}${pdfPath}\"}")
+            fi
+        done
     done
 
     jsonFiles=$(echo "${files[@]}" | jq -r '{path:.path, download_url:.download_url}' | jq -s)

--- a/.github/workflows/generate-upload-manifest.yml
+++ b/.github/workflows/generate-upload-manifest.yml
@@ -28,4 +28,4 @@ jobs:
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Upload manifest.json to ${{ matrix.env }}
         run: |
-          aws s3 cp output/manifest.json s3://sensible-so-utility-bucket-${{ matrix.env }}/SAMPLE_DOCUMENTS/manifest.json
+          aws s3 cp output/manifest.json s3://sensible-so-utility-bucket-${{ matrix.env }}/SAMPLE_DOCUMENTS/manifest_v2.json


### PR DESCRIPTION
updated bash script to find all docs matching `${fileName}_sample` grep and add them to the manifest

~Should not be merged until this one is deployed to prod: https://github.com/sensible-hq/sensible/pull/2298~

Manifest has been versioned, so merging is fine.